### PR TITLE
Styling updates to render a more user-friendly print view (hide header and navbar, introduce style to add page break elements)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pdf
+
+_site/
+.sass-cache/
+.jekyll-metadata
+*.css.map
+*.lock

--- a/NISTIR_Cover_Front.md
+++ b/NISTIR_Cover_Front.md
@@ -1,3 +1,4 @@
+
 <div class="text-right" markdown="1">
 
 # NIST Internal Report 8112 (Draft)

--- a/static/css/NISTPages.css
+++ b/static/css/NISTPages.css
@@ -102,7 +102,7 @@ ul.audiences li {
   width: 139px;
 }
 
-.navbar-fixed-left + .container {
+.container {
   padding-left: 160px;
 }
 
@@ -130,16 +130,16 @@ table>thead>tr>th,table>tbody>tr>th,table>tfoot>tr>th,table>thead>tr>td,table>tb
   padding:8px;
   line-height:1.42857143;
   vertical-align:top;
-  border-top:1px solid #ddd
+  border:1px solid #ddd
 }
 
 table>thead>tr>th{
   vertical-align:bottom;
-  border-bottom:2px solid #ddd
+  border-bottom:2px solid #ddd;
 }
 
 table>caption+thead>tr:first-child>th,table>colgroup+thead>tr:first-child>th,table>thead:first-child>tr:first-child>th,table>caption+thead>tr:first-child>td,table>colgroup+thead>tr:first-child>td,table>thead:first-child>tr:first-child>td{
-  border-top:0
+  border-top:1px solid #ddd;
 }
 
 table>tbody+tbody{
@@ -149,5 +149,3 @@ table>tbody+tbody{
 table table{
   background-color:#fff
 }
-
-

--- a/static/css/NISTStyle.css
+++ b/static/css/NISTStyle.css
@@ -198,6 +198,19 @@ td,th{
 		box-shadow:none !important
 	}
 
+	.nist-header {
+		display: none;
+	}
+
+	div.container {
+		padding-left:30px;
+		padding-right:30px;
+	}
+
+	.breaker{
+		page-break-before: always;
+	}
+
 	a,a:visited{
 		text-decoration:underline
 		color: purple;
@@ -246,7 +259,8 @@ td,th{
 	}
 
 	.navbar{
-		display:none
+		display:none;
+		width: 0px;
 	}
 
 	.table td,.table th{


### PR DESCRIPTION
- Fixed cover page rendering
- added gitignore file
- Remove nist-header from print view
- Set explicit padding (margins) on content container
- Introduce a style to produce page breaks in print view
- Explicitly set the width of .navbar elements to 0 in print view
- Added table borders