### PR TITLE
Adding quotation marks around the title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Site settings
-title: NISTIR 8112 Attribute Metadata: A Proposed Schema for Evaluating Federated Attributes (Draft)
+title: "NISTIR 8112 Attribute Metadata: A Proposed Schema for Evaluating Federated Attributes (Draft)"
 description: "Public Draft for NIST Internal Report 8112 Attribute Metadata"
 baseurl: "/NISTIR-8112" # the subpath of your site, e.g. /blog
 url: "https://pages.nist.gov/" # the base hostname & protocol for your site


### PR DESCRIPTION
Stephen suggested that there might be an issue since a colon was added that wasn't in the title previously. Worth seeing if it fixes our problem.